### PR TITLE
Omit redundant `enumerable: false`

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@
 
   if (Object.defineProperty) {
     Object.defineProperty(Array.prototype, 'findIndex', {
-      value: findIndex, configurable: true, enumerable: false, writable: true
+      value: findIndex, configurable: true, writable: true
     });
   } else {
     Array.prototype.findIndex = findIndex;


### PR DESCRIPTION
`enumerable: false` is the default, so there’s no need to include it.
