### PR TITLE
Correct the casing in the require statement in docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Browser:
 
 ```javascript
 // component(1)
-require('array.prototype.findIndex');
+require('array.prototype.findindex');
 ```
 
 Code example:


### PR DESCRIPTION
Casing breaks on case sensitive operating systems (Typically Linux).

I believe we had the same issue in the `array.prototype.find` package :).

Thanks for a nice package!
