### PR TITLE
Update .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,29 @@
 bower.json
+
+## from .gitignore:
+
+# Numerous always-ignore extensions
+*.diff
+*.err
+*.orig
+*.log
+*~
+
+# OS or Editor folders
+.DS_Store
+.cache
+Icon?
+
+# Folders to ignore
+.hg
+.svn
+
+# Node.js package manager
+/node_modules
+/npm-debug.log
+
+# Other stuff
+*.pyc
+/tmp
+
+# Project stuff


### PR DESCRIPTION
Per https://github.com/paulmillr/Array.prototype.findIndex/commit/11e9fce59c758dddd2810e60de91223d9a78bb62#commitcomment-8901378, when a `.npmignore` is absent, `.gitignore` is used - now that `.npmignore` is present, these other things should continue to be npm ignored.
