### PR TITLE
Separate feature detect from the polyfill

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{js,json}]
+indent_style = tab

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "Array.prototype.findIndex",
-  "main": "index.js",
+  "main": "detect.js",
   "version": "1.0.0",
   "homepage": "https://github.com/paulmillr/Array.prototype.findIndex",
   "authors": [

--- a/bower.json
+++ b/bower.json
@@ -1,19 +1,19 @@
 {
-  "name": "Array.prototype.findIndex",
-  "main": "detect.js",
-  "version": "1.0.0",
-  "homepage": "https://github.com/paulmillr/Array.prototype.findIndex",
-  "authors": [
-    "Paul Miller <http://paulmillr.com>"
-  ],
-  "description": "Array.prototype.findIndex ES6 polyfill.",
-  "keywords": ["Array.prototype.findIndex", "findIndex", "es6"],
-  "license": "MIT",
-  "ignore": [
-    "**/.*",
-    "node_modules",
-    "bower_components",
-    "test",
-    "tests"
-  ]
+	"name": "Array.prototype.findIndex",
+	"main": "index.js",
+	"version": "1.0.0",
+	"homepage": "https://github.com/paulmillr/Array.prototype.findIndex",
+	"authors": [
+		"Paul Miller <http://paulmillr.com>"
+	],
+	"description": "Array.prototype.findIndex ES6 polyfill.",
+	"keywords": ["Array.prototype.findIndex", "findIndex", "es6"],
+	"license": "MIT",
+	"ignore": [
+		"**/.*",
+		"node_modules",
+		"bower_components",
+		"test",
+		"tests"
+	]
 }

--- a/component.json
+++ b/component.json
@@ -7,8 +7,9 @@
   "dependencies": {},
   "development": {},
   "license": "MIT",
-  "main": "index.js",
+  "main": "detect.js",
   "scripts": [
-    "index.js"
+    "polyfill.js",
+    "detect.js"
   ]
 }

--- a/component.json
+++ b/component.json
@@ -12,6 +12,6 @@
 		"polyfill.js",
 		"shim.js",
 		"implementation.js",
-		"inedx.js"
+		"index.js"
 	]
 }

--- a/component.json
+++ b/component.json
@@ -1,15 +1,17 @@
 {
-  "name": "Array.prototype.findIndex",
-  "repo": "paulmillr/Array.prototype.findIndex",
-  "description": "Array.prototype.findIndex ES6 polyfill.",
-  "version": "1.0.0",
-  "keywords": ["Array.prototype.findIndex", "findIndex", "es6"],
-  "dependencies": {},
-  "development": {},
-  "license": "MIT",
-  "main": "detect.js",
-  "scripts": [
-    "polyfill.js",
-    "detect.js"
-  ]
+	"name": "Array.prototype.findIndex",
+	"repo": "paulmillr/Array.prototype.findIndex",
+	"description": "Array.prototype.findIndex ES6 polyfill.",
+	"version": "1.0.0",
+	"keywords": ["Array.prototype.findIndex", "findIndex", "es6"],
+	"dependencies": {},
+	"development": {},
+	"license": "MIT",
+	"main": "index.js",
+	"scripts": [
+		"polyfill.js",
+		"shim.js",
+		"implementation.js",
+		"inedx.js"
+	]
 }

--- a/detect.js
+++ b/detect.js
@@ -1,0 +1,3 @@
+if (!Array.prototype.findIndex) {
+  require('./polyfill');
+}

--- a/detect.js
+++ b/detect.js
@@ -1,3 +1,3 @@
 if (!Array.prototype.findIndex) {
-  require('./polyfill');
+	require('./polyfill');
 }

--- a/implementation.js
+++ b/implementation.js
@@ -1,0 +1,19 @@
+// Array.prototype.findIndex - MIT License (c) 2013 Paul Miller <http://paulmillr.com>
+// For all details and docs: <https://github.com/paulmillr/Array.prototype.findIndex>
+'use strict';
+var ES = require('es-abstract/es6');
+
+module.exports = function findIndex(predicate) {
+	var list = ES.ToObject(this);
+	var length = ES.ToLength(ES.ToLength(list.length));
+	if (!ES.IsCallable(predicate)) {
+		throw new TypeError('Array#findIndex: predicate must be a function');
+	}
+	if (length === 0) return -1;
+	var thisArg = arguments[1];
+	for (var i = 0, value; i < length; i++) {
+		value = list[i];
+		if (ES.Call(predicate, thisArg, [value, i, list])) return i;
+	}
+	return -1;
+};

--- a/index.js
+++ b/index.js
@@ -1,0 +1,23 @@
+'use strict';
+
+var define = require('define-properties');
+var ES = require('es-abstract/es6');
+
+var implementation = require('./implementation');
+var getPolyfill = require('./polyfill');
+var shim = require('./shim');
+
+var slice = Array.prototype.slice;
+
+var boundShim = function findIndex(array, predicate) {
+	ES.RequireObjectCoercible(array);
+	return implementation.apply(array, predicate);
+};
+
+define(boundShim, {
+	implementation: implementation,
+	getPolyfill: getPolyfill,
+	shim: shim
+});
+
+module.exports = boundShim;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Array.prototype.findIndex ES6 polyfill.",
   "keywords": ["Array.prototype.findIndex", "findIndex", "es6"],
-  "main": "index.js",
+  "main": "detect.js",
   "scripts": {
     "test": "mocha test.js"
   },

--- a/package.json
+++ b/package.json
@@ -1,23 +1,32 @@
 {
-  "name": "array.prototype.findindex",
-  "version": "1.0.0",
-  "description": "Array.prototype.findIndex ES6 polyfill.",
-  "keywords": ["Array.prototype.findIndex", "findIndex", "es6"],
-  "main": "detect.js",
-  "scripts": {
-    "test": "mocha test.js"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/paulmillr/Array.prototype.findIndex.git"
-  },
-  "author": "Paul Miller <http://paulmillr.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/paulmillr/Array.prototype.findIndex/issues"
-  },
-  "devDependencies": {
-    "chai": "~1.9.1",
-    "mocha": "~1.21.4"
-  }
+	"name": "array.prototype.findindex",
+	"version": "1.0.0",
+	"description": "Array.prototype.findIndex ES6 polyfill.",
+	"keywords": [
+		"Array.prototype.findIndex",
+		"findIndex",
+		"es6"
+	],
+	"main": "index.js",
+	"scripts": {
+		"test": "es-shim-api --bound && mocha test.js"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git://github.com/paulmillr/Array.prototype.findIndex.git"
+	},
+	"author": "Paul Miller <http://paulmillr.com>",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/paulmillr/Array.prototype.findIndex/issues"
+	},
+	"devDependencies": {
+		"@es-shims/api": "^1.0.0",
+		"chai": "~1.9.1",
+		"mocha": "~1.21.4"
+	},
+	"dependencies": {
+		"define-properties": "^1.1.2",
+		"es-abstract": "^1.5.0"
+	}
 }

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,25 +1,12 @@
-// Array.prototype.findIndex - MIT License (c) 2013 Paul Miller <http://paulmillr.com>
-// For all details and docs: <https://github.com/paulmillr/Array.prototype.findIndex>
-(function (globals) {
-  Array.prototype.findIndex = function findIndex (predicate) {
-    var list = Object(this);
-    var length = Math.max(0, list.length) >>> 0; // ES.ToUint32;
-    if (length === 0) return -1;
-    if (typeof predicate !== 'function' || Object.prototype.toString.call(predicate) !== '[object Function]') {
-      throw new TypeError('Array#findIndex: predicate must be a function');
-    }
-    var thisArg = arguments.length > 1 ? arguments[1] : undefined;
-    for (var i = 0; i < length; i++) {
-      if (predicate.call(thisArg, list[i], i, list)) return i;
-    }
-    return -1;
-  };
+'use strict';
 
-  if (Object.defineProperty) {
-    try {
-      Object.defineProperty(Array.prototype, 'findIndex', {
-        value: findIndex, configurable: true, writable: true
-      });
-    } catch(e) {}
-  }
-}(this));
+module.exports = function getPolyfill() {
+	// Detect if an implementation exists
+	// Detect early implementations which skipped holes in sparse arrays
+	var implemented = Array.prototype.findIndex && ([, 1].findIndex(function (item, idx) {
+		return idx === 0;
+	}) === 0);
+
+
+	return implemented ? Array.prototype.findIndex : require('./implementation');
+};

--- a/polyfill.js
+++ b/polyfill.js
@@ -1,9 +1,7 @@
 // Array.prototype.findIndex - MIT License (c) 2013 Paul Miller <http://paulmillr.com>
 // For all details and docs: <https://github.com/paulmillr/Array.prototype.findIndex>
 (function (globals) {
-  if (Array.prototype.findIndex) return;
-
-  var findIndex = function(predicate) {
+  Array.prototype.findIndex = function findIndex (predicate) {
     var list = Object(this);
     var length = Math.max(0, list.length) >>> 0; // ES.ToUint32;
     if (length === 0) return -1;
@@ -23,9 +21,5 @@
         value: findIndex, configurable: true, writable: true
       });
     } catch(e) {}
-  }
-
-  if (!Array.prototype.findIndex) {
-    Array.prototype.findIndex = findIndex;
   }
 }(this));

--- a/shim.js
+++ b/shim.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var define = require('define-properties');
+var getPolyfill = require('./polyfill');
+
+module.exports = function shimArrayPrototypeFindIndex() {
+	var polyfill = getPolyfill();
+
+	define(Array.prototype, { findIndex: polyfill }, {
+		findIndex: function () {
+			return Array.prototype.findIndex !== polyfill;
+		}
+	});
+
+	return polyfill;
+};

--- a/test.js
+++ b/test.js
@@ -1,86 +1,104 @@
 var expect = require("chai").expect;
-var arrayFindIndex = require('./polyfill');
+var arrayFindIndex = require('./');
 
-var runArrayTests = function() {
-  var list = [5, 10, 15, 20];
+var runTests = function(findIndex) {
+	var list = [5, 10, 15, 20];
 
-  describe('Array#findIndex', function() {
-    it('should have a length of 1', function() {
-      expect(Array.prototype.findIndex.length).to.equal(1);
-    });
+	describe('Array#findIndex', function() {
+		it('should have a length of 1', function() {
+			expect(findIndex.length).to.equal(1);
+		});
 
-    it('should find item key by predicate', function() {
-      var result = list.findIndex(function(item) { return item === 15; });
-      expect(result).to.equal(2);
-    });
+		it('should find item key by predicate', function() {
+			var result = findIndex.call(list, function(item) { return item === 15; });
+			expect(result).to.equal(2);
+		});
 
-    it('should return -1 when nothing matched', function() {
-      var result = list.findIndex(function(item) { return item === 'a'; });
-      expect(result).to.equal(-1);
-    });
+		it('should return -1 when nothing matched', function() {
+			var result = findIndex.call(list, function(item) { return item === 'a'; });
+			expect(result).to.equal(-1);
+		});
 
-    it('should throw TypeError when function was not passed', function() {
-      expect(function() { list.findIndex(); }).to.throw(TypeError);
-    });
+		it('should throw TypeError when function was not passed', function() {
+			expect(function() { list.findIndex(); }).to.throw(TypeError);
+		});
 
-    it('should receive all three parameters', function() {
-      var index = list.findIndex(function(value, index, arr) {
-        expect(list[index]).to.equal(value);
-        expect(list).to.eql(arr);
-        return false;
-      });
-      expect(index).to.equal(-1);
-    });
+		it('should receive all three parameters', function() {
+			var index = findIndex.call(list, function(value, index, arr) {
+				expect(list[index]).to.equal(value);
+				expect(list).to.eql(arr);
+				return false;
+			});
+			expect(index).to.equal(-1);
+		});
 
-    it('should work with the context argument', function() {
-      var context = {};
-      [1].findIndex(function() { expect(this).to.equal(context); }, context);
-    });
+		it('should work with the context argument', function() {
+			var context = {};
+			findIndex.call([1], function() { expect(this).to.equal(context); }, context);
+		});
 
-    it('should work with an array-like object', function() {
-      var obj = { '0': 1, '1': 2, '2': 3, length: 3 };
-      var foundIndex = Array.prototype.findIndex.call(obj, function(item) { return item === 2; });
-      expect(foundIndex).to.equal(1);
-    });
+		it('should work with an array-like object', function() {
+			var obj = { '0': 1, '1': 2, '2': 3, length: 3 };
+			var foundIndex = findIndex.call(obj, function(item) { return item === 2; });
+			expect(foundIndex).to.equal(1);
+		});
 
-    it('should work with an array-like object with negative length', function() {
-      var obj = { '0': 1, '1': 2, '2': 3, length: -3 };
-      var foundIndex = Array.prototype.findIndex.call(obj, function(item) {
-        throw new Error('should not reach here');
-      });
-      expect(foundIndex).to.equal(-1);
-    });
+		it('should work with an array-like object with negative length', function() {
+			var obj = { '0': 1, '1': 2, '2': 3, length: -3 };
+			var foundIndex = findIndex.call(obj, function(item) {
+				throw new Error('should not reach here');
+			});
+			expect(foundIndex).to.equal(-1);
+		});
 
-    it('should work with a sparse array', function() {
-      var obj = [1, , undefined];
-      expect(1 in obj).to.equal(false);
-      var seen = [];
-      var foundIndex = obj.findIndex(function(item, idx) {
-        seen.push([idx, item]);
-        return item === undefined && idx === 2;
-      });
-      expect(foundIndex).to.equal(2);
-      expect(seen).to.eql([[0, 1], [1, undefined], [2, undefined]]);
-    });
+		it('should work with a sparse array', function() {
+			var obj = [1, , undefined];
+			expect(1 in obj).to.equal(false);
+			var seen = [];
+			var foundIndex = findIndex.call(obj, function(item, idx) {
+				seen.push([idx, item]);
+				return item === undefined && idx === 2;
+			});
+			expect(foundIndex).to.equal(2);
+			expect(seen).to.eql([[0, 1], [1, undefined], [2, undefined]]);
+		});
 
-    it('should work with a sparse array-like object', function() {
-      var obj = { '0': 1, '2': undefined, length: 3.2 };
-      var seen = [];
-      var foundIndex = Array.prototype.findIndex.call(obj, function(item, idx) {
-        seen.push([idx, item]);
-        return false;
-      });
-      expect(foundIndex).to.equal(-1);
-      expect(seen).to.eql([[0, 1], [1, undefined], [2, undefined]]);
-    });
-  });
+		it('should work with a sparse array-like object', function() {
+			var obj = { '0': 1, '2': undefined, length: 3.2 };
+			var seen = [];
+			var foundIndex = findIndex.call(obj, function(item, idx) {
+				seen.push([idx, item]);
+				return false;
+			});
+			expect(foundIndex).to.equal(-1);
+			expect(seen).to.eql([[0, 1], [1, undefined], [2, undefined]]);
+		});
+	});
 };
 
-describe('clean Object.prototype', runArrayTests);
+describe('polyfill', function() {
+	describe('clean Object.prototype', function() {
+		runTests(arrayFindIndex.implementation)
+	});
 
-describe('polluted Object.prototype', function() {
-  Object.prototype[1] = 42;
-  runArrayTests();
-  delete Object.prototype[1];
+	describe('polluted Object.prototype', function() {
+		Object.prototype[1] = 42;
+		runTests(arrayFindIndex.implementation);
+		delete Object.prototype[1];
+	});
 });
 
+describe('shim', function() {
+	arrayFindIndex.shim();
+	var implementation = Array.prototype.findIndex;
+
+	describe('clean Object.prototype', function() {
+		runTests(implementation);
+	});
+
+	describe('polluted Object.prototype', function() {
+		Object.prototype[1] = 42;
+		runTests(implementation);
+		delete Object.prototype[1];
+	});
+});

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
 var expect = require("chai").expect;
-var arrayFindIndex = require('./');
+var arrayFindIndex = require('./polyfill');
 
 var runArrayTests = function() {
   var list = [5, 10, 15, 20];


### PR DESCRIPTION
With the two together, it is impossible to test whether the module
works in engines which partially support Array.prototype.findIndex.

With the two separated, we can test in all engines and we can more
easily use this polyfill inside of the [Financial Times's polyfill-service](https://github.com/Financial-Times/polyfill-service).
